### PR TITLE
refactor: reduce amount of console logging

### DIFF
--- a/app/components/ConnectButton/ConnectedAccount.js
+++ b/app/components/ConnectButton/ConnectedAccount.js
@@ -8,7 +8,7 @@ const ConnectedAccount = styled.button`
   ${tw`
   border-2 border-yearn-blue rounded-xl
   py-1
-  px-4 items-center justify-center align-middle 
+  px-4 items-center justify-center align-middle
   text-xs flex hover:text-yearn-blue
   bg-gradient-to-r from-gray-900 to-yearn-blue
   text-white
@@ -28,10 +28,13 @@ export default function Account(props) {
       try {
         const addressEnsName = await ens.reverse(account);
         if (addressEnsName) {
-          return setAddress(addressEnsName);
+          setAddress(addressEnsName);
         }
       } catch (err) {
-        console.error(err);
+        // Although an error is thrown if no ens name is found during lookup,
+        // failure to find an ENS name for an address is not an error, and is
+        // currently the most likely outcome during a lookup, so no need to log
+        // nor handle the "error".
       }
     };
     setAddressEnsName();

--- a/app/middleware/drizzleWeb3.js
+++ b/app/middleware/drizzleWeb3.js
@@ -18,7 +18,7 @@ export const drizzleWeb3Middleware = drizzleWeb3 => store => next => action => {
       etherscan: {
         apiKey: 'GEQXZDY67RZ4QHNU1A57QVPNDV3RP1RYH4',
       },
-      logging: true,
+      logging: false,
       simplifyResponse: false,
       store: localStorage,
     });

--- a/app/utils/abiStorage.js
+++ b/app/utils/abiStorage.js
@@ -31,13 +31,13 @@ export const addAbiToCache = async (address, providedAbi) => {
     abiHashByAddress[address] = abiHash;
     setLocalStorageItem('abiByHash', abiByHash);
     setLocalStorageItem('abiHashByAddress', abiHashByAddress);
+    console.log(`Cached abi for address ${address}`);
     return newAbi;
   };
   const cachedAbi = getAbiFromCache(address);
   if (providedAbi) {
     abi = cacheAbi(providedAbi);
   } else if (!cachedAbi) {
-    console.log('No cached abi found');
     abi = await fetchAbi(address);
     cacheAbi(abi);
     await delay(etherscanDelayTime);
@@ -57,8 +57,6 @@ export const getCachedAbi = async address => {
   let abi = getAbiFromCache(address);
   if (!abi) {
     abi = await addAbiToCache(address);
-  } else {
-    console.log(`Loaded cached ABI: ${address}`);
   }
   return abi;
 };


### PR DESCRIPTION
PR to try to reduce console  logging noise.

Have remove console error for failed ens lookup, as not having an ens name is not an error.

Have turned off logging for web3 batch calls, but these can be turned on locally as and when needed.

Have updated logging around abi caching, so that we don't log every instance of fetching an abi from cache, but instead log when an abi is not found in cache and is then stored.  To me it makes more sense to log the infrequent case of "abi not found => store" rather than the normal expect case of "loaded abi from cache". 

This is now the console output related to abis for a user with no existing abis cached.
![image](https://user-images.githubusercontent.com/395388/102991346-ecd35c00-4510-11eb-9732-caa02ce085d7.png)
