### PR TITLE
feat(cover): replace addCommasToNumber with formatNumber

### DIFF
--- a/app/components/CoverCard/index.js
+++ b/app/components/CoverCard/index.js
@@ -5,7 +5,7 @@ import {
   getShortenedAddress,
   abbreviateRelativeTime,
   daysFromNow,
-  addCommasToNumber,
+  formatNumber,
   removeDecimals,
 } from 'utils/string';
 import Icon from 'components/Icon';
@@ -178,7 +178,7 @@ export default function CoverCard(props) {
     protocol.coverObjects[protocol.claimNonce].collateralStaked;
 
   const { collateralName } = protocol.coverObjects[protocol.claimNonce];
-  const totalCollateralStr = addCommasToNumber(removeDecimals(totalCollateral));
+  const totalCollateralStr = formatNumber(removeDecimals(totalCollateral));
 
   const countDown = abbreviateRelativeTime(currentTime, expirationTimestamp);
   const coverDaysLeft = daysFromNow(currentTime, expirationTimestamp);

--- a/app/components/CoverDetailCardBuy/index.js
+++ b/app/components/CoverDetailCardBuy/index.js
@@ -14,7 +14,7 @@ import {
   selectTokenAllowance,
 } from 'containers/App/selectors';
 import { calculateAmountNeeded, calculateAmountOutFromBuy } from 'utils/cover';
-import { addCommasToNumber } from 'utils/string';
+import { formatNumber } from 'utils/string';
 import Web3 from 'web3';
 import BigNumber from 'bignumber.js';
 
@@ -439,8 +439,8 @@ function CoverDetailCardBuy(props) {
       <BottomRight>
         <AmountText>Summary</AmountText>
         <SummaryText>
-          You will spend {addCommasToNumber(daiSpendText)} DAI to acquire{' '}
-          {addCommasToNumber(amount)} {protocolDisplayName} claim tokens. Each
+          You will spend {formatNumber(daiSpendText)} DAI to acquire{' '}
+          {formatNumber(amount)} {protocolDisplayName} claim tokens. Each
           {protocolDisplayName} claim token will be redeemable for 1{' '}
           {collateralName} in the event of a hack.
         </SummaryText>

--- a/app/components/CoverDetailCardSell/index.js
+++ b/app/components/CoverDetailCardSell/index.js
@@ -13,6 +13,7 @@ import {
   calculateAmountOutFromSell,
   calculateAmountInFromSell,
 } from 'utils/cover';
+import { formatNumber } from 'utils/string';
 import Web3 from 'web3';
 
 const StyledTokenIcon = styled(TokenIcon)`
@@ -389,8 +390,8 @@ function CoverDetailCardSell(props) {
       <BottomRight>
         <AmountText>Summary</AmountText>
         <SummaryText>
-          You will sell {amount || '0'} claim tokens and will get back{' '}
-          {equivalentDai} DAI.
+          You will sell {formatNumber(amount) || '0'} claim tokens and will get
+          back {formatNumber(equivalentDai)} DAI.
         </SummaryText>
         <ButtonWrapper>
           <ButtonFilled variant="contained" color="primary" onClick={sellCover}>

--- a/app/components/CoverTallCard/index.js
+++ b/app/components/CoverTallCard/index.js
@@ -4,7 +4,7 @@ import { selectContractData } from 'containers/App/selectors';
 import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
 import TokenIcon from 'components/TokenIcon';
-import { addCommasToNumber } from 'utils/string';
+import { formatNumber } from 'utils/string';
 import { calculateAmountNeeded } from 'utils/cover';
 
 const Wrapper = styled.div`
@@ -109,10 +109,7 @@ const ChangeText = ({ amount, operation }) => {
     PlusOrMinusComponent = MinusText;
   }
 
-  const amountText = amount
-    ? `${operator}${addCommasToNumber(Number(amount).toFixed(2))}`
-    : '';
-
+  const amountText = amount ? `${operator}${formatNumber(Number(amount))}` : '';
   return <PlusOrMinusComponent>{amountText}</PlusOrMinusComponent>;
 };
 
@@ -148,7 +145,7 @@ export default function CoverTallCard(props) {
     protocol,
     `coverObjects.${claimNonce}.tokens.claimTotalSupply.hex`,
   );
-  const totalSupply = addCommasToNumber(
+  const totalSupply = formatNumber(
     new BigNumber(totalSupplyHex)
       .dividedBy(10 ** collateralDecimals)
       .toFixed(0),
@@ -205,7 +202,7 @@ export default function CoverTallCard(props) {
 
   const equivalentToText =
     equivalentToAmount && equivalentToAmount !== '0'
-      ? `+${addCommasToNumber(Number(equivalentToAmount).toFixed(2))}`
+      ? `+${formatNumber(Number(equivalentToAmount))}`
       : '';
 
   const accountCoverage = new BigNumber(claimTokenBalanceOf)

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -35,12 +35,12 @@ export const abbreviateNumber = value => {
   return newValue;
 };
 
-export const addCommasToNumber = val => {
-  if (!val) return '';
-  while (/(\d+)(\d{3})/.test(val.toString())) {
-    val = val.toString().replace(/(\d+)(\d{3})/, '$1' + ',' + '$2');
-  }
-  return val;
+export const formatNumber = val => {
+  if (!val || _.isNaN(val)) return '';
+  return Number(val).toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    useGrouping: true,
+  });
 };
 
 export const removeDecimals = val => {


### PR DESCRIPTION
Replace addCommasToNumber function with new function that uses Number(val).toLocaleString which is I have configured to group thousands in the same way.  This fixes the issue whereby passing number with lots of decimals caused the function to add separators to the decimal part of the number.

This approach can handle numbers with many decimals and will trim then down to 2 and will also group the thousands.  It also will use different separator based on users locale as some countries use . instead of ,

However I did run into some issues that i could not fix in time, which are related to converting very high DAI values. So whilst this fixes one issue, it does introduce other issues to fix, so not sure whether to merge or not...

Examples of high DAI value issues:

If DAI number is of a certain size when buying/selling, the tall cover card shows an empty value
![image](https://user-images.githubusercontent.com/395388/104108819-cad32b00-52bf-11eb-8890-c030a85d35f0.png)

![image](https://user-images.githubusercontent.com/395388/104108823-d3c3fc80-52bf-11eb-83b6-68be56ebbbad.png)

At the certain large DAI value, cover amount shows 0
![image](https://user-images.githubusercontent.com/395388/104108900-767c7b00-52c0-11eb-899a-355edc6b419a.png)


