### PR TITLE
fix: disable vault deposit button if value is 0

### DIFF
--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -152,6 +152,12 @@ export default function VaultControls(props) {
       if (totalAssetsBN.plus(depositGweiAmount).gte(depositLimitBN)) {
         return 'Vault deposit limit reached.';
       }
+      // fix: disable deposit button if value is 0
+      // note: resolves issue #252 from iearn-finance repo
+      // this issue only affects v2 & is mis-ticketed as v1 (iearn-finance)
+      if (depositGweiAmount <= 0) {
+        return 'Value must be greater than 0.';
+      }
     } else if (
       vault.type === 'v1' &&
       vault.address === '0xBA2E7Fed597fd0E3e70f5130BcDbbFE06bB94fe1'


### PR DESCRIPTION
## Description

Disable a deposit if the value entered is 0, which stops a user from depositing 0 into a vault and potentially spending hefty gas fees on an empty deposit. Namely, `depositsDisabled` is updated with an additional `if` statement that checks `depositGweiAmount` is not 0.

This fix is true for any v2 vault and can help make sure users don't spend nominal (10-20 USD) to thousands of USD on a contract that deposits a 0 value. 

Note that this resolves [issue #252 from iearn-finance repo](https://github.com/yearn/iearn-finance/issues/252), which states the issue actually occurs for v2 and not v1. Thus, issue #252 in `iearn-finance` can be moved to `yearn-finance` and resolved with this fix.

## Steps to reproduce
1. Go to: "Invest" > "Vault" (from v2 homepage)
2. Click on any vault and click "Deposit"
- Example (before fix) after clicking "Deposit" button => purely paying ~1.5 ETH in gas on a 0 value deposit
<img width="1333" alt="ETH-vault-zero-value" src="https://user-images.githubusercontent.com/13358940/111020060-d35fe480-8388-11eb-9c22-9e831d201f8b.png">


**Expected behavior**:
The user should not be allowed to deposit any value (disable button) if the deposit value is 0.
- Example (after fix) of disabling the deposit if the value is 0: 

![yearn-issue-252](https://user-images.githubusercontent.com/13358940/111020113-14f08f80-8389-11eb-93bb-7b42eef0acb7.gif)

## Versions
- npm: 7.6.3
- Browser: Brave