### PR TITLE
feat: github action that checks diff for payment code

### DIFF
--- a/.github/workflows/check-payment-code.yml
+++ b/.github/workflows/check-payment-code.yml
@@ -1,0 +1,14 @@
+name: 'check-payment-code-in-diff'
+on: [push]
+
+jobs:
+  test_something:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: patcito/check-keywords-in-diff@v0.2.63
+        with:
+          branch: develop
+          notify_issue: true
+          title: payment related code
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
github action to help avoid missing payment related modifications in commits,
it's no silver bullet of course but could help

It posts a comment on the PR issue if PR diff contains:
- any constant
- web3 related code (cacheSend etc)
- any ethereum address (it fetches from yearn API to check if it's  a known vault or token address and displays a warning if not found)

action url: https://github.com/patcito/check-keywords-in-diff

![commit-bot](https://user-images.githubusercontent.com/26435/117359552-9ddb0180-aec8-11eb-9973-139a0698846d.png)

