### PR TITLE
Fix: deposit button for yvBOOST-ETH v2 vault

### DIFF
--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -706,6 +706,9 @@ export default function VaultControls(props) {
       </Wrapper>
     );
   } else if (vault.isYVBoost) {
+    const balance = sellToken ? sellToken.balanceRaw : tokenBalance;
+    const disabled = new BigNumber(depositGweiAmount).isGreaterThan(new BigNumber(balance));
+
     vaultControlsWrapper = (
       <Wrapper>
         <Box display="flex" flexDirection="column" width={1}>
@@ -755,10 +758,7 @@ export default function VaultControls(props) {
                 <ButtonGroup width={1} style={{ marginTop: '-10px' }}>
                   <ActionButton
                     className="action-button dark"
-                    disabled={
-                      depositGweiAmount >
-                      (sellToken ? sellToken.balanceRaw : tokenBalance)
-                    }
+                    disabled={disabled}
                     handler={() => zapperZapYvBoostEthLP()}
                     text={
                       (tokenAllowance !== undefined &&


### PR DESCRIPTION
I've just noticed this behaviour when trying to zap into yvBOOST-ETH v2 vault. Any numbers between 1 and 10 as the deposit amount deactivated the Deposit button. Everything below 0 and over 10 was fine :joy: 

I guess it's because we're returning `depositGweiAmount` as a string from the react state and then the comparison is based on two strings because `sellToken.balanceRaw` is also a string.

Fixed the yvBOOST deposit button for now by using `BigNumber` comparisons.