### PR TITLE
feat: add button to deposit for a friend

### DIFF
--- a/app/components/Navbar/menuLinks.js
+++ b/app/components/Navbar/menuLinks.js
@@ -11,43 +11,6 @@ export const menuLinks = {
       description: '',
     },
   ],
-  // protect: {
-  //  href: '/cover',
-  //  title: 'Protect',
-  //  description: '',
-  //},
-  // earn: {
-  //   href: 'https://yearn.finance/earn',
-  //   title: 'yUSD',
-  //   description: 'Stable coin index',
-  // },
-  // products: [
-  //   {
-  //     href: '/vaults',
-  //     title: 'yVaults',
-  //     description: 'Deposit and earn',
-  //   },
-  //   {
-  //     href: '/cover',
-  //     title: 'yCover',
-  //     description: 'Cover smart contract risk',
-  //   },
-  //   {
-  //     href: 'https://yearn.finance/earn',
-  //     title: 'yUSD',
-  //     description: 'Stable coin index',
-  //   },
-  //   {
-  //     href: 'https://yearn.finance/zap',
-  //     title: 'Zap',
-  //     description: 'Zap in and out of the pools',
-  //   },
-  // ],
-  // stats: {
-  //   href: 'https://yearn.finance/stats',
-  //   title: 'Stats',
-  //   description: "Get a quick glance at how yearn's vaults are performing",
-  // },
   gov: [
     {
       href: 'https://gov.yearn.finance/',

--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -505,6 +505,33 @@ export default function VaultControls(props) {
     dispatch(depositPickleSLPInFarm(payload));
   };
 
+  const giftDeposit = () => {
+    const giftAddress = prompt(
+      'Provide an ethereum address you would like to gift a deposit to',
+      '0x...',
+    );
+    plausible('gift-deposit', {
+      props: {
+        vault: vault.address,
+        token: token.address,
+        amount: depositGweiAmount,
+        zap: false,
+        giftAddress,
+      },
+    });
+    dispatch(
+      depositToVault({
+        vaultContract,
+        tokenContract,
+        depositAmount: depositGweiAmount,
+        decimals,
+        pureEthereum,
+        hasAllowance: vault.hasAllowance,
+        giftAddress,
+      }),
+    );
+  };
+
   const deposit = () => {
     plausible('deposit', {
       props: {
@@ -1112,6 +1139,27 @@ export default function VaultControls(props) {
                       enabledTooltipText={approvalExplainer}
                     />
                   </Box>
+                  {depositHasBeenApproved &&
+                  !willZapIn &&
+                  vault.type === 'v2' ? (
+                    <Box width={isScreenMd ? '190px' : '100%'} ml={5}>
+                      <ActionButton
+                        disabled={
+                          !vaultContract || !tokenContract || !!depositsDisabled
+                        }
+                        handler={() => giftDeposit()}
+                        text="Gift Deposit"
+                        title="Gift a deposit to a friend"
+                        showTooltipWhenDisabled
+                        disabledTooltipText={
+                          depositsDisabled ||
+                          'Connect your wallet to deposit into vault'
+                        }
+                        showTooltipWhenEnabled={!depositHasBeenApproved}
+                        enabledTooltipText={approvalExplainer}
+                      />
+                    </Box>
+                  ) : null}
                 </ButtonGroup>
               </Box>
               {zapperError &&

--- a/app/containers/Vaults/saga.js
+++ b/app/containers/Vaults/saga.js
@@ -262,6 +262,7 @@ function* depositToVault(action) {
     depositAmount,
     pureEthereum,
     hasAllowance,
+    giftAddress,
   } = action.payload;
 
   const account = yield select(selectAccount());
@@ -281,9 +282,20 @@ function* depositToVault(action) {
           vaultContract.address,
         );
       }
-      yield call(vaultContract.methods.deposit.cacheSend, depositAmount, {
-        from: account,
-      });
+      if (giftAddress) {
+        yield call(
+          vaultContract.methods.deposit.cacheSend,
+          depositAmount,
+          giftAddress,
+          {
+            from: account,
+          },
+        );
+      } else {
+        yield call(vaultContract.methods.deposit.cacheSend, depositAmount, {
+          from: account,
+        });
+      }
     } else {
       const { zapContract } = vaultContract;
       if (zapContract) {


### PR DESCRIPTION
Needed something like this to deposit for a relative and implemented this instead of using etherscan, could be useful for other people. What do you think? It shows a prompt with an input for the eth address.

![image](https://user-images.githubusercontent.com/26435/121425423-6f4abd80-c983-11eb-98c2-33b2f78a40b4.png)
![gift-prompt](https://user-images.githubusercontent.com/26435/121426333-88a03980-c984-11eb-8b96-a593013eb18e.png)
