### PR TITLE
fix: remove APY tooltip on new endorsed vaults [WEB-402]

### DIFF
--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -597,6 +597,9 @@ const Vault = (props) => {
       </div>
     );
   }
+  if (apyRecommended === 'NEW ✨') {
+    apyTooltip = null;
+  }
 
   let versionTooltip = null;
   if (vault.fees && vault.fees.general) {


### PR DESCRIPTION
- Remove APY tooltip on new endorsed vaults.