### PR TITLE
fix: don't render VaultControls when hidden

### DIFF
--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -930,7 +930,7 @@ const Vault = (props) => {
       </ColumnListDev>
     );
   } else {
-    vaultControls = (
+    vaultControls = active && (
       <VaultControls
         vault={vault}
         token={tokenContractData}


### PR DESCRIPTION
should save us up to 400 re-rendering on load
this commit is back ported from #366 in case it doesn't get merged

