### PR TITLE
fix https://github.com/yearn/yearn-finance/issues/111

### DIFF
--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -1332,7 +1332,7 @@ function MaxButton({ maxAmount, amountSetter, gweiAmountSetter, decimals }) {
       onClick={() => {
         const normalizedAmount = new BigNumber(maxAmount)
           .dividedBy(10 ** decimals)
-          .toFixed(2);
+          .toFixed(5);
 
         amountSetter(normalizedAmount);
         gweiAmountSetter(maxAmount);


### PR DESCRIPTION
"Max" buttons on vaults/cover should show more than 2 decimals #111

wallet/vault balance  now shows 5 decimals instead of 2 (vaults page)

