### PR TITLE
fix: improve handling of decimals in UI

### DIFF
--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -1332,7 +1332,7 @@ function MaxButton({ maxAmount, amountSetter, gweiAmountSetter, decimals }) {
       onClick={() => {
         const normalizedAmount = new BigNumber(maxAmount)
           .dividedBy(10 ** decimals)
-          .toFixed(2);
+          .toFixed(5);
 
         amountSetter(normalizedAmount);
         gweiAmountSetter(maxAmount);

--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -1332,7 +1332,7 @@ function MaxButton({ maxAmount, amountSetter, gweiAmountSetter, decimals }) {
       onClick={() => {
         const normalizedAmount = new BigNumber(maxAmount)
           .dividedBy(10 ** decimals)
-          .toFixed(2);
+          .toFixed(5, 1);
 
         amountSetter(normalizedAmount);
         gweiAmountSetter(maxAmount);

--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -1332,7 +1332,7 @@ function MaxButton({ maxAmount, amountSetter, gweiAmountSetter, decimals }) {
       onClick={() => {
         const normalizedAmount = new BigNumber(maxAmount)
           .dividedBy(10 ** decimals)
-          .toFixed(5, 1);
+          .toFixed(4, 1);
 
         amountSetter(normalizedAmount);
         gweiAmountSetter(maxAmount);

--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -1332,7 +1332,7 @@ function MaxButton({ maxAmount, amountSetter, gweiAmountSetter, decimals }) {
       onClick={() => {
         const normalizedAmount = new BigNumber(maxAmount)
           .dividedBy(10 ** decimals)
-          .toFixed(5);
+          .toFixed(2);
 
         amountSetter(normalizedAmount);
         gweiAmountSetter(maxAmount);


### PR DESCRIPTION
issue#110: Vaults UI currently rounds a user's holdings up, but this leads them to potential issues where instead of clicking "max", they manually type in more than they actually hold in their wallet when trying to deposit to vaults and get an error, but they don't know why.

For example: If you max deposit 6.666Tokens, it will be 6.67.
6.666 < 6.67.
So the deposit action will fail.

issue#111: Yearn v2 UI currently shows two decimals for "max", and it would be helpful to show more than this.

The wallet/vault balance should show 5 decimals, and round down in the UI instead of up.

Two issue are connected with the function usage of BigNumber.toFixed().

its reference book is here:
https://mikemcl.github.io/bignumber.js/#toFix

There are some usage samples in the reference book:
x = 3.456
y = new BigNumber(x)
x.toFixed() // '3'
y.toFixed() // '3.456'
y.toFixed(0) // '3'
x.toFixed(2) // '3.46'
y.toFixed(2) // '3.46'
y.toFixed(2, 1) // '3.45' (ROUND_DOWN)
x.toFixed(5) // '3.45600'
y.toFixed(5) // '3.45600'

Now we have the answer to resolve issue#110 and issue#111.

change function BigNumber.toFixed(2) to .toFixed(5, 1) for more decimals and round down.

for example.
prev 6.666666 -> 6.67
now 6.666666 -> 6.66666