### PR TITLE
fix: handle unsupported EIP-1559 network error [WEB-704]

### DIFF
--- a/app/containers/Zapper/saga.js
+++ b/app/containers/Zapper/saga.js
@@ -197,11 +197,7 @@ function* zapIn(action) {
             contractAddress: approvalTransaction.to,
           });
         };
-        yield call(
-          web3.eth.sendTransaction,
-          approvalTransaction,
-          broadcastTransaction,
-        );
+        yield call(sendTx, web3, approvalTransaction, broadcastTransaction);
       }
     }
 
@@ -226,11 +222,7 @@ function* zapIn(action) {
         contractAddress: poolAddress,
       });
     };
-    yield call(
-      web3.eth.sendTransaction,
-      zapInTransaction,
-      broadcastTransaction,
-    );
+    yield call(sendTx, web3, zapInTransaction, broadcastTransaction);
   } catch (error) {
     let errorMessage = '';
     if (error && error.message) {
@@ -329,11 +321,7 @@ function* zapOut(action) {
           contractAddress: poolAddress,
         });
       };
-      yield call(
-        web3.eth.sendTransaction,
-        approvalTransaction,
-        broadcastTransaction,
-      );
+      yield call(sendTx, web3, approvalTransaction, broadcastTransaction);
     }
 
     const zapOutTransaction = yield call(
@@ -358,11 +346,7 @@ function* zapOut(action) {
         contractAddress: poolAddress,
       });
     };
-    yield call(
-      web3.eth.sendTransaction,
-      zapOutTransaction,
-      broadcastTransaction,
-    );
+    yield call(sendTx, web3, zapOutTransaction, broadcastTransaction);
   } catch (error) {
     console.log('Zap Failed', error);
     let errorMessage = '';
@@ -377,6 +361,53 @@ function* zapOut(action) {
     );
   }
 }
+
+const sendTx = async (web3, transactionObject, callback) => {
+  const txObj = transactionObject;
+  const GASPRICES_API = 'https://api.blocknative.com/gasprices/blockprices';
+  const HEADERS = {
+    Authorization: process.env.BLOCKNATIVE_DAPP_ID,
+  };
+  const DEFAULT_CONFIDENCE_LEVEL = 95;
+
+  let estimatedPrice;
+  try {
+    const response = await request(GASPRICES_API, { headers: HEADERS });
+    estimatedPrice = _.first(response.blockPrices).estimatedPrices.find(
+      ({ confidence }) => confidence === DEFAULT_CONFIDENCE_LEVEL,
+    );
+  } catch (error) {
+    console.log(error);
+  }
+
+  if (estimatedPrice) {
+    delete txObj.gasPrice;
+    txObj.maxPriorityFeePerGas = web3.utils.toWei(
+      estimatedPrice.maxPriorityFeePerGas.toString(),
+      'gwei',
+    );
+    txObj.maxFeePerGas = web3.utils.toWei(
+      estimatedPrice.maxFeePerGas.toString(),
+      'gwei',
+    );
+  }
+
+  return web3.eth.sendTransaction(txObj, callback).catch((error) => {
+    // Retry as a legacy tx, for specific error in metamask v10 + ledger transactions
+    // Metamask RPC Error: Invalid transaction params: params specify an EIP-1559 transaction but the current network does not support EIP-1559
+    if (error.code === -32602) {
+      delete txObj.maxPriorityFeePerGas;
+      delete txObj.maxFeePerGas;
+      txObj.gasPrice = web3.utils.toWei(
+        estimatedPrice.price.toString(),
+        'gwei',
+      );
+      return web3.eth.sendTransaction(txObj, callback);
+    }
+
+    return Promise.reject(error);
+  });
+};
 
 export default function* rootSaga() {
   yield takeLatest(INIT_ZAPPER, initializeZapper);

--- a/app/containers/Zapper/saga.js
+++ b/app/containers/Zapper/saga.js
@@ -370,6 +370,7 @@ const sendTx = async (web3, transactionObject, callback) => {
   };
   const DEFAULT_CONFIDENCE_LEVEL = 95;
 
+  const gasPrice = await web3.eth.getGasPrice();
   let estimatedPrice;
   try {
     const response = await request(GASPRICES_API, { headers: HEADERS });
@@ -398,10 +399,9 @@ const sendTx = async (web3, transactionObject, callback) => {
     if (error.code === -32602) {
       delete txObj.maxPriorityFeePerGas;
       delete txObj.maxFeePerGas;
-      txObj.gasPrice = web3.utils.toWei(
-        estimatedPrice.price.toString(),
-        'gwei',
-      );
+      txObj.gasPrice = estimatedPrice
+        ? web3.utils.toWei(estimatedPrice.price.toString(), 'gwei')
+        : gasPrice;
       return web3.eth.sendTransaction(txObj, callback);
     }
 

--- a/app/drizzle/store/DrizzleContract.js
+++ b/app/drizzle/store/DrizzleContract.js
@@ -115,43 +115,55 @@ class DrizzleContract {
         );
       }
 
-      return call
-        .send(sendArgs)
-        .on('transactionHash', (txHash) => {
-          persistTxHash = txHash;
+      const sendTx = (txCall) =>
+        txCall
+          .send(sendArgs)
+          .on('transactionHash', (txHash) => {
+            persistTxHash = txHash;
+            contract.store.dispatch({
+              type: 'TX_BROADCASTED',
+              txHash,
+              contractAddress: contract.address,
+            });
+          })
+          .on('confirmation', (confirmationNumber, receipt) => {
+            contract.store.dispatch({
+              type: 'TX_CONFIRMAITON',
+              confirmationReceipt: receipt,
+              txHash: persistTxHash,
+            });
+            return Promise.resolve();
+          })
+          .on('receipt', (receipt) => {
+            contract.store.dispatch({
+              type: 'TX_SUCCESSFUL',
+              receipt,
+              txHash: persistTxHash,
+              contractAddress: contract.address,
+            });
+          })
+          .on('error', (error) => {
+            contract.store.dispatch({
+              type: 'TX_ERROR',
+              error,
+            });
+          });
 
-          contract.store.dispatch({
-            type: 'TX_BROADCASTED',
-            txHash,
-            contractAddress: contract.address,
-          });
-        })
-        .on('confirmation', (confirmationNumber, receipt) => {
-          contract.store.dispatch({
-            type: 'TX_CONFIRMAITON',
-            confirmationReceipt: receipt,
-            txHash: persistTxHash,
-          });
-          return Promise.resolve();
-        })
-        .on('receipt', (receipt) => {
-          contract.store.dispatch({
-            type: 'TX_SUCCESSFUL',
-            receipt,
-            txHash: persistTxHash,
-            contractAddress: contract.address,
-          });
-        })
-        .on('error', (error, receipt) => {
-          console.error(error);
-          console.error(receipt);
+      return sendTx(call).catch((error) => {
+        // Retry as a legacy tx, for specific error in metamask v10 + ledger transactions
+        // Metamask RPC Error: Invalid transaction params: params specify an EIP-1559 transaction but the current network does not support EIP-1559
+        if (error.code === -32602) {
+          delete sendArgs.maxPriorityFeePerGas;
+          delete sendArgs.maxFeePerGas;
+          sendArgs.gasPrice = web3.utils.toWei(
+            estimatedPrice.price.toString(),
+            'gwei',
+          );
+          return sendTx(call);
+        }
 
-          contract.store.dispatch({
-            type: 'TX_ERROR',
-            error,
-          });
-          return Promise.reject(error);
-        });
+        return Promise.reject(error);
+      });
     };
   }
 }

--- a/app/drizzle/store/DrizzleContract.js
+++ b/app/drizzle/store/DrizzleContract.js
@@ -94,6 +94,7 @@ class DrizzleContract {
       const call = contract.methods[fnName](...newArgs);
       let persistTxHash;
 
+      const gasPrice = await web3.eth.getGasPrice();
       let estimatedPrice;
       try {
         const response = await request(GASPRICES_API, { headers: HEADERS });
@@ -155,10 +156,9 @@ class DrizzleContract {
         if (error.code === -32602) {
           delete sendArgs.maxPriorityFeePerGas;
           delete sendArgs.maxFeePerGas;
-          sendArgs.gasPrice = web3.utils.toWei(
-            estimatedPrice.price.toString(),
-            'gwei',
-          );
+          sendArgs.gasPrice = estimatedPrice
+            ? web3.utils.toWei(estimatedPrice.price.toString(), 'gwei')
+            : gasPrice;
           return sendTx(call);
         }
 


### PR DESCRIPTION
- Add support for legacy transactions when metamask v10 + hw wallets errors out trying to use EIP-1559 type 2 transactions.