### PR TITLE
refactor: remove old API dependency

### DIFF
--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -1384,9 +1384,23 @@ const Vault = (props) => {
     );
 
   const minDecimals = setDecimals(decimals);
-  const showVaults =
-    (!vaultsToHide.includes(vault.address) || balanceOf >= 10 ** minDecimals) &&
+  const migrationAvailable = _.get(vault, 'migration.available');
+  const userHasBalance = balanceOf >= 10 ** minDecimals;
+  const vaultIsV1Type = vault.type === 'v1';
+  const vaultIsSpecial = vault.special;
+
+  let showVaults =
+    (!vaultsToHide.includes(vault.address) || userHasBalance) &&
     !hackedOrToBeAbsolutelyRemoved.includes(vault.address);
+
+  if (migrationAvailable && !userHasBalance) {
+    showVaults = false;
+  }
+
+  if (vaultIsV1Type && !vaultIsSpecial && !userHasBalance) {
+    showVaults = false;
+  }
+
   let finalVaults = null;
   let showLabel = 'SHOW';
   if (isMigratable) {

--- a/app/containers/App/reducer.js
+++ b/app/containers/App/reducer.js
@@ -13,6 +13,8 @@ import { VAULTS_LOADED, ROUTE_CHANGED } from './constants';
 import {
   USER_VAULT_STATISTICS_LOADED,
   AMPLIFY_VAULTS_ADDRESSES,
+  BACKSCRATCHER_ADDRESS,
+  YVBOOST_ADDRESS,
 } from '../Vaults/constants';
 
 const backscratcherAddress = '0xc5bDdf9843308380375a611c18B50Fb9341f502A';
@@ -55,6 +57,19 @@ const appReducer = (state = initialState, action) =>
       draft.ready = ready;
     };
 
+    const mapSpecialVaults = (vault) => {
+      const vaultIsBackscratcher = vault.address === BACKSCRATCHER_ADDRESS;
+      const vaultIsYvBoost = vault.address === YVBOOST_ADDRESS;
+      if (vaultIsBackscratcher) {
+        vault.displayName = 'yveCRV';
+        vault.token.icon = `https://raw.githubusercontent.com/yearn/yearn-assets/master/icons/multichain-tokens/1/${BACKSCRATCHER_ADDRESS}/logo-128.png`;
+      } else if (vaultIsYvBoost) {
+        vault.displayName = 'yvBOOST';
+        vault.token.icon = `https://raw.githubusercontent.com/yearn/yearn-assets/master/icons/multichain-tokens/1/${YVBOOST_ADDRESS}/logo-128.png`;
+      }
+      return vault;
+    };
+
     switch (action.type) {
       case USER_VAULT_STATISTICS_LOADED:
         draft.loading.vaults = false;
@@ -72,7 +87,9 @@ const appReducer = (state = initialState, action) =>
         draft.amplifyVaults = action.vaults.filter((vault) =>
           isAmplifyVault(vault),
         );
-        draft.vaults = action.vaults.filter((vault) => !isAmplifyVault(vault));
+        draft.vaults = action.vaults
+          .map(mapSpecialVaults)
+          .filter((vault) => !isAmplifyVault(vault));
         checkReadyState();
         break;
       }


### PR DESCRIPTION
- Removed old API dependency in as unobtrusive way as possible
- Confirmed all vaults from yearn.finance are present 
- Confirmed all APY and vault assets are correct
- Confirmed vault ordering is correct (one minor caveat is yvBOOST and yveCRV order are switched, but I actually think this is fine.. otherwise order is perfect. can change this if desired)
- Confirmed all special vault display names and icon URLs are correct (there are two special vault icon overrides that rely on yearn-assets/icons rather than multichain. everything else uses multichain)