### PR TITLE
fix: n/a for usdm vault

### DIFF
--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -590,7 +590,7 @@ const Vault = (props) => {
       </div>
     );
   }
-  if (apyRecommended === 'NEW ✨') {
+  if (apyRecommended === 'NEW ✨' || apyRecommended === 'N/A') {
     apyTooltip = null;
   }
 

--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -495,6 +495,8 @@ const Vault = (props) => {
 
   if (vault.new) {
     apyRecommended = 'NEW ✨';
+  } else if (vault.address === '0x6FAfCA7f49B4Fd9dC38117469cd31A1E5aec91F5') {
+    apyRecommended = 'N/A';
   }
 
   let apyTooltip = (


### PR DESCRIPTION
Update the `Net APY` for the [Curve USDM Vault](https://etherscan.io/address/0x6FAfCA7f49B4Fd9dC38117469cd31A1E5aec91F5) to `N/A`.